### PR TITLE
Fix Docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 COPY package*.json ./
+RUN mkdir -p node-zerox/scripts
+COPY node-zerox/scripts/install-dependencies.js node-zerox/scripts/
 RUN npm install
 
 COPY . .


### PR DESCRIPTION
## Summary
- ensure `node-zerox/scripts/install-dependencies.js` exists during `npm install`

## Testing
- `pytest -q`
- `npm test` *(fails: ts-node not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_685b0136e4a8832697b2950065e17f82